### PR TITLE
Plan duration selector

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,8 +3,8 @@ import OrderSummary from './components/OrderSummary';
 
 function App() {
   return (
-    <div class='bg-mobile sm:bg-desktop bg-no-repeat [background-size:100%_50vh] bg-pale-blue w-100 h-screen p-6'>
-      <Card className='bg-white m-auto max-w-[450px] max-h-[700px]'>
+    <div className='bg-mobile sm:bg-desktop bg-no-repeat [background-size:100%_50vh] bg-pale-blue w-100 h-screen p-6'>
+      <Card className='bg-white m-auto max-w-[450px] min-h-[700px]'>
         <OrderSummary>
         </OrderSummary>
       </Card>

--- a/src/components/DurationMenu.js
+++ b/src/components/DurationMenu.js
@@ -1,27 +1,27 @@
 import { useState } from 'react';
 
 function DurationMenu (props) {
+
+    // For making a visable focus since the radio is hidden
     const [focusOn, setFocusOn] = useState('');
+    const onFocus = (e) => {
+        setFocusOn(`${e.target.value}`)
+    }
+
+    // Remove focus styling from radios when focus moves to button
+    const onBlur = () => {
+        setFocusOn('');
+    }
+
+    //Send selected value up to calling component
+    const onClick = (e) => {
+        props.onSelect(e.target.attributes.for.value);
+    }
 
     const durationToTimeSpan = (duration) => {
         return duration === 'Annual' ? 'year' : 'month';
     }
 
-    const onClick = (e) => {
-        console.log(e);
-        props.onSelect(e.target.attributes.for.value);
-    }
-
-    // Create a visable focus since the radio that is actually focused in hidden
-    const onFocus = (e) => {
-        // console.log(e.target.value)
-        setFocusOn(`${e.target.value}`)
-    }
-
-    const onBlur = () => {
-        setFocusOn('');
-    }
-    
     return (
         <div className='flex flex-col items-center xxs:flex-row m-4'>
             {props.options.map(option => {
@@ -30,7 +30,7 @@ function DurationMenu (props) {
 
                         <label htmlFor={option.duration}
                         onClick={onClick}
-                        className='block cursor-pointer underline text-desaturated-blue hover:text-bright-blue/80 hover:font-extrabold font-bold first-line:text-bright-blue hover:firstline:text-bright-blue/80 first-line:underline'>
+                        className='block cursor-pointer underline text-desaturated-blue hover:text-bright-blue/80 hover:font-extrabold font-bold first-line:text-bright-blue first-line:underline'>
                             {/* Content of the label */}
                             {`${option.duration}`}
                             <br />

--- a/src/components/DurationMenu.js
+++ b/src/components/DurationMenu.js
@@ -1,7 +1,7 @@
 function DurationMenu (props) {
 
     //Send selected value up to calling component
-    const onChange = (e) => {
+    const onClick = (e) => {
         console.log(e.target.value);
         props.onSelect(e.target.value);
     }
@@ -26,7 +26,7 @@ function DurationMenu (props) {
                         </label>
 
                         {/* Hidden checkbox input */}
-                        <input type='checkbox' id={option.duration} name='duration' value={option.duration} onChange={onChange} className='appearance-none absolute h-full w-full top-0 left-0 z-10 rounded-xl cursor-pointer hover:border hover:border-bright-blue hover:border-4' />
+                        <input type='checkbox' id={option.duration} name='duration' value={option.duration} onClick={onClick} className='appearance-none absolute h-full w-full top-0 left-0 z-10 rounded-xl cursor-pointer hover:border hover:border-bright-blue hover:border-4' />
                     </div>
                 );
             })}

--- a/src/components/DurationMenu.js
+++ b/src/components/DurationMenu.js
@@ -2,7 +2,7 @@ function DurationMenu (props) {
 
     //Send selected value up to calling component
     const onClick = (e) => {
-        console.log(e.target.value);
+        // console.log(e.target.value);
         props.onSelect(e.target.value);
     }
 

--- a/src/components/DurationMenu.js
+++ b/src/components/DurationMenu.js
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+
+function DurationMenu (props) {
+    const [focusOn, setFocusOn] = useState('');
+
+    const durationToTimeSpan = (duration) => {
+        return duration === 'Annual' ? 'year' : 'month';
+    }
+
+    const onClick = (e) => {
+        console.log(e);
+        props.onSelect(e.target.attributes.for.value);
+    }
+
+    // Create a visable focus since the radio that is actually focused in hidden
+    const onFocus = (e) => {
+        // console.log(e.target.value)
+        setFocusOn(`${e.target.value}`)
+    }
+
+    const onBlur = () => {
+        setFocusOn('');
+    }
+    
+    return (
+        <div className='flex flex-col items-center xxs:flex-row m-4'>
+            {props.options.map(option => {
+                return (
+                    <div key={option.duration} className={`inline m-1 p-4 pb-0 w-full xxs:w-1/2 bg-very-pale-blue rounded-xl ${focusOn === option.duration && 'outline outline-bright-blue'}`}>
+
+                        <label htmlFor={option.duration}
+                        onClick={onClick}
+                        className='block cursor-pointer underline text-desaturated-blue hover:text-bright-blue/80 hover:font-extrabold font-bold first-line:text-bright-blue hover:firstline:text-bright-blue/80 first-line:underline'>
+                            {/* Content of the label */}
+                            {`${option.duration}`}
+                            <br />
+                            {`$${option.price}/${durationToTimeSpan(option.duration)}`}
+                        </label>
+
+                        {/* Hidden radio input */}
+                        <input type='radio' id={option.duration} name='duration' value={option.duration} onFocus={onFocus} onBlur={onBlur} className='opacity-0' />
+                    </div>
+                );
+            })}
+        </div> 
+    );
+}
+
+export default DurationMenu;

--- a/src/components/DurationMenu.js
+++ b/src/components/DurationMenu.js
@@ -1,21 +1,9 @@
-import { useState } from 'react';
-
 function DurationMenu (props) {
 
-    // For making a visable focus since the radio is hidden
-    const [focusOn, setFocusOn] = useState('');
-    const onFocus = (e) => {
-        setFocusOn(`${e.target.value}`)
-    }
-
-    // Remove focus styling from radios when focus moves to button
-    const onBlur = () => {
-        setFocusOn('');
-    }
-
     //Send selected value up to calling component
-    const onClick = (e) => {
-        props.onSelect(e.target.attributes.for.value);
+    const onChange = (e) => {
+        console.log(e.target.value);
+        props.onSelect(e.target.value);
     }
 
     const durationToTimeSpan = (duration) => {
@@ -26,19 +14,19 @@ function DurationMenu (props) {
         <div className='flex flex-col items-center xxs:flex-row m-4'>
             {props.options.map(option => {
                 return (
-                    <div key={option.duration} className={`inline m-1 p-4 pb-0 w-full xxs:w-1/2 bg-very-pale-blue rounded-xl ${focusOn === option.duration && 'outline outline-bright-blue'}`}>
+                    <div key={option.duration} className='inline relative m-1 p-4 w-full xxs:w-1/2 bg-very-pale-blue rounded-xl'>
 
-                        <label htmlFor={option.duration}
-                        onClick={onClick}
-                        className='block cursor-pointer underline text-desaturated-blue hover:text-bright-blue/80 hover:font-extrabold font-bold first-line:text-bright-blue first-line:underline'>
+                        <label htmlFor={option.duration} 
+                        
+                        className='block relative cursor-pointer underline text-desaturated-blue font-bold first-line:text-bright-blue first-line:underline'>
                             {/* Content of the label */}
                             {`${option.duration}`}
                             <br />
                             {`$${option.price}/${durationToTimeSpan(option.duration)}`}
                         </label>
 
-                        {/* Hidden radio input */}
-                        <input type='radio' id={option.duration} name='duration' value={option.duration} onFocus={onFocus} onBlur={onBlur} className='opacity-0' />
+                        {/* Hidden checkbox input */}
+                        <input type='checkbox' id={option.duration} name='duration' value={option.duration} onChange={onChange} className='appearance-none absolute h-full w-full top-0 left-0 z-10 rounded-xl cursor-pointer hover:border hover:border-bright-blue hover:border-4' />
                     </div>
                 );
             })}

--- a/src/components/DurationMenu.js
+++ b/src/components/DurationMenu.js
@@ -14,7 +14,7 @@ function DurationMenu (props) {
         <div className='flex flex-col items-center xxs:flex-row m-4'>
             {props.options.map(option => {
                 return (
-                    <div key={option.duration} className='inline relative m-1 p-4 w-full xxs:w-1/2 bg-very-pale-blue rounded-xl'>
+                    <div className='inline relative m-1 p-4 w-full xxs:w-1/2 bg-very-pale-blue rounded-xl'>
 
                         <label htmlFor={option.duration} 
                         

--- a/src/components/OrderSummaryForm.js
+++ b/src/components/OrderSummaryForm.js
@@ -5,7 +5,7 @@ function OrderSummaryForm() {
     return (
         <form className='pb-6 flex flex-col'>
             <OrderSummaryPlanSelect />
-            <button className='block my-5 py-4 text-white font-bold bg-bright-blue hover:bg-bright-blue/80 rounded-xl shadow-xl shadow-bright-blue/20'>Proceed to Payment</button>
+            <button className='block my-5 py-4 text-white font-bold bg-bright-blue hover:bg-bright-blue/80 rounded-xl shadow-xl shadow-bright-blue/20 focus:outline focus:outline-red-500 focus:outline-2'>Proceed to Payment</button>
             <a className='p-2 text-desaturated-blue hover:text-black text-sm font-bold hover:underline' href='#'>Cancel Order</a>
         </form>
     );

--- a/src/components/OrderSummaryPlanSelect.js
+++ b/src/components/OrderSummaryPlanSelect.js
@@ -28,7 +28,8 @@ function OrderSummaryPlanSelect () {
     // Handler takes 'duration' property passed up from DurationMenu and makes it the selected option
     const onSelectHandler = (selected) => {
         toggleDurationMenu();
-        setSelectedOption(selected === 'Annual' ? 0 : 1);
+        const option = (selected === 'Annual' ? 0 : 1);
+        setSelectedOption(option);
     }
 
     // Toggle function shared by handlers
@@ -48,9 +49,9 @@ function OrderSummaryPlanSelect () {
                 <div className='my-4 py-4 bg-very-pale-blue rounded-xl flex justify-around items-center' id='plan-selector'>
                     <div className='flex items-center'>
                         <img className='pr-4' src={icon} alt='' />
-                        <div className=''>
+                        <div>
                             <h3 className='font-bold p-1'>{planOptions[selectedOption].duration} Plan</h3>
-                            <p className='text-desaturated-blue'>${`${planOptions[selectedOption].price}/${durationToTimeSpan(planOptions[selectedOption].duration)}`}</p>
+                            <p className='text-desaturated-blue'>{`$${planOptions[selectedOption].price}/${durationToTimeSpan(planOptions[selectedOption].duration)}`}</p>
                         </div>
                     </div>    
                     <button className='text-bright-blue hover:text-bright-blue/80 underline hover:no-underline font-bold' onClick={onClickHandler} >Change</button>

--- a/src/components/OrderSummaryPlanSelect.js
+++ b/src/components/OrderSummaryPlanSelect.js
@@ -1,12 +1,11 @@
-import { useState, useRef } from 'react';
-
+import { useState } from 'react';
 import DurationMenu from './DurationMenu';
 
 import icon from '../images/icon-music.svg';
-import React from 'react';
 
 function OrderSummaryPlanSelect () {
 
+    // Tempary test data to test functionality on this component and DurationMenu
     const planOptions = [
         {
             duration: 'Annual',
@@ -20,17 +19,19 @@ function OrderSummaryPlanSelect () {
     const [displayDurationMenu, setDisplayDurationMenu] = useState(false);
     const [selectedOption, setSelectedOption] = useState(0);
 
+    // Switches from displaying the selected option to displaying the DurationMenu
     const onClickHandler = (e) => {
         e.preventDefault();
-        console.log('click');
         toggleDurationMenu();
     }
 
+    // Handler takes 'duration' property passed up from DurationMenu and makes it the selected option
     const onSelectHandler = (selected) => {
         toggleDurationMenu();
         setSelectedOption(selected === 'Annual' ? 0 : 1);
     }
 
+    // Toggle function shared by handlers
     const toggleDurationMenu = () => {
         setDisplayDurationMenu(!displayDurationMenu);
     }

--- a/src/components/OrderSummaryPlanSelect.js
+++ b/src/components/OrderSummaryPlanSelect.js
@@ -1,18 +1,61 @@
+import { useState, useRef } from 'react';
+
+import DurationMenu from './DurationMenu';
+
 import icon from '../images/icon-music.svg';
+import React from 'react';
 
 function OrderSummaryPlanSelect () {
 
+    const planOptions = [
+        {
+            duration: 'Annual',
+            price: 59.99
+        },
+        {
+            duration: 'Monthly',
+            price: 6
+        },
+    ];
+    const [displayDurationMenu, setDisplayDurationMenu] = useState(false);
+    const [selectedOption, setSelectedOption] = useState(0);
+
+    const onClickHandler = (e) => {
+        e.preventDefault();
+        console.log('click');
+        toggleDurationMenu();
+    }
+
+    const onSelectHandler = (selected) => {
+        toggleDurationMenu();
+        setSelectedOption(selected === 'Annual' ? 0 : 1);
+    }
+
+    const toggleDurationMenu = () => {
+        setDisplayDurationMenu(!displayDurationMenu);
+    }
+
+    const durationToTimeSpan = (duration) => {
+        return duration === 'Annual' ? 'year' : 'month';
+    }
+
     return (
-        <div className='my-4 py-4 bg-very-pale-blue rounded-xl flex justify-around items-center' id='plan-selector'>
-            <div className='flex items-center'>
-                <img className='pr-4' src={icon} alt='' />
-                <div className=''>
-                    <h3 className='font-bold p-1'>Annual Plan</h3>
-                    <p className='text-desaturated-blue'>$59.99/year</p>
+        <>  
+            {displayDurationMenu && <DurationMenu options={planOptions} onSelect={onSelectHandler} /> }  
+
+            {!displayDurationMenu && 
+                <div className='my-4 py-4 bg-very-pale-blue rounded-xl flex justify-around items-center' id='plan-selector'>
+                    <div className='flex items-center'>
+                        <img className='pr-4' src={icon} alt='' />
+                        <div className=''>
+                            <h3 className='font-bold p-1'>{planOptions[selectedOption].duration} Plan</h3>
+                            <p className='text-desaturated-blue'>${`${planOptions[selectedOption].price}/${durationToTimeSpan(planOptions[selectedOption].duration)}`}</p>
+                        </div>
+                    </div>    
+                    <button className='text-bright-blue hover:text-bright-blue/80 underline hover:no-underline font-bold' onClick={onClickHandler} >Change</button>
                 </div>
-            </div>    
-            <a className='text-bright-blue hover:text-bright-blue/80 underline hover:no-underline font-bold' href='#'>Change</a>
-        </div>
+            }
+        </>    
     );
 }
 


### PR DESCRIPTION
On the order summary page, clicking the 'change' button by the selected plan should give the user the option to choose between an annual plan and a monthly plan. Once the user selects one of the options they should be returned to the original page appearance with the plan they selected displayed.

- The elements should be focusable
- On wider screens the 'Annual' and 'Monthly' options should be shown side by side like in [this planned idea](https://github.com/AccessEleanorJohnson/FMOrderSummaryApp/blob/main/planning/wireframes/wireframing-split-monthly-annual-button.png). 
- On narrower screens the options should be stacked one above the other

- None of the functionality of the 'Proceed to Payment' button or 'Cancel Order' need to be done at this point

These changes can be checked out on the [github pages site](https://accesseleanorjohnson.github.io/FMOrderSummaryApp/#)